### PR TITLE
Make psychopy player blocking

### DIFF
--- a/auditory_stimulation/view/psychopy_view.py
+++ b/auditory_stimulation/view/psychopy_view.py
@@ -35,7 +35,6 @@ class PsychopyView(AView):
         self.window.flip()
 
         self._sound_player(stimulus.audio)
-        self.wait(10)  # TODO: this should not be here
 
     def _update_new_primer(self, primer: str) -> None:
         prompt = self.__create_text_box(primer)

--- a/auditory_stimulation/view/sound_players.py
+++ b/auditory_stimulation/view/sound_players.py
@@ -1,12 +1,12 @@
 import numpy as np
+import psychopy.core
 from psychopy.sound.backend_pygame import SoundPygame
 
 from auditory_stimulation.auditory_stimulus.auditory_stimulus import Audio
 
 
 def psychopy_player(audio: Audio, play_audio: bool = True) -> None:
-    """ Plays the given audio. Function is NON blocking and returns after the audio has STARTED playing
-    TODO: MAKE BLOCKING
+    """ Plays the given audio. Function is blocking and returns after the audio has finished playing
 
     :param audio: a dataclass consisting of
      * audio: Nx2 dimensional numpy array of the audio. Audio needs to be in the range [-1, 1]
@@ -33,3 +33,5 @@ def psychopy_player(audio: Audio, play_audio: bool = True) -> None:
     # use the pygame backend, as it allows to play sounds from arrays, not only from files
     sound = SoundPygame(value=audio.audio)
     sound.play()
+    duration = sound.getDuration()
+    psychopy.core.wait(duration)


### PR DESCRIPTION
Closes #5 

Adding a `psychopy.core.wait` is the recommended solution according to the `SoundPygame` documentation, as the audio is played on a separate thread.